### PR TITLE
Added skip_lines_number option to ignore unnecessary initial lines

### DIFF
--- a/spec/doctordata_spec.rb
+++ b/spec/doctordata_spec.rb
@@ -6,6 +6,7 @@ require 'csv'
 RSpec.describe Doctordata do
   let(:csv_str){ "keyA,#commentB,keyC[0],keyC[1]\na1,b1,c11,c12\na2,b2,c21,c22\n" }
   let(:csv_table){ CSV.parse(csv_str, :headers => true)}
+  let(:result){ [{"keyA"=>"a1", "keyC"=>["c11", "c12"]}, {"keyA"=>"a2", "keyC"=>["c21", "c22"]}] }
 
   describe 'Doctordata' do
     it "has a version number" do
@@ -18,7 +19,25 @@ RSpec.describe Doctordata do
     end
     context 'with valid csv_table' do
       it "returns correct json" do
-        expect(subject).to eq [{"keyA"=>"a1", "keyC"=>["c11", "c12"]}, {"keyA"=>"a2", "keyC"=>["c21", "c22"]}]
+        expect(subject).to eq result
+      end
+    end
+  end
+  describe 'from_csv_str' do
+    let(:options){ {} }
+    subject do
+      Doctordata::Parser.from_csv_str(csv_str, options)
+    end
+    context 'with valid csv_str' do
+      it "returns correct json" do
+        expect(subject).to eq result
+      end
+    end
+    context 'with valid csv_str and skip option' do
+      let(:csv_str){ "THIS_IS_UNNECESSARY_LINE\nkeyA,#commentB,keyC[0],keyC[1]\na1,b1,c11,c12\na2,b2,c21,c22\n" }
+      let(:options){ { skip_lines_number: 1 } }
+      it "returns correct json" do
+        expect(subject).to eq result
       end
     end
   end


### PR DESCRIPTION
Sometimes, we want to write hints of following columns at the initial lines.
So, I added a option to ignore unnecessary initial lines.